### PR TITLE
Replace Markdown It Plugin Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5122,6 +5122,12 @@
             "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
             "dev": true
         },
+        "lodash.deburr": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
+            "integrity": "sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=",
+            "dev": true
+        },
         "lodash.flattendeep": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -5134,6 +5140,16 @@
             "integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=",
             "dev": true
         },
+        "lodash.kebabcase": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.0.1.tgz",
+            "integrity": "sha1-XmO8mqKlVi/zuXynry+APeG8uQ4=",
+            "dev": true,
+            "requires": {
+                "lodash.deburr": "^4.0.0",
+                "lodash.words": "^4.0.0"
+            }
+        },
         "lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5144,6 +5160,12 @@
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
             "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
+        "lodash.words": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-4.2.0.tgz",
+            "integrity": "sha1-Xs/q+Oz4rKqODIOGKV8Zk8nPQDY=",
             "dev": true
         },
         "log-symbols": {
@@ -5262,13 +5284,14 @@
             "integrity": "sha1-ABm0P9Au7+zi8ZYKKJX7qBpARpU=",
             "dev": true
         },
-        "markdown-it-named-headers": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/markdown-it-named-headers/-/markdown-it-named-headers-0.0.4.tgz",
-            "integrity": "sha1-gu/CgyQkCmsed7mq5QF3HV81HB8=",
+        "markdown-it-named-headings": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/markdown-it-named-headings/-/markdown-it-named-headings-1.1.0.tgz",
+            "integrity": "sha1-L2zSmADeHp3eCiTo1NEnXfQuoX0=",
             "dev": true,
             "requires": {
-                "string": "^3.0.1"
+                "lodash.kebabcase": "4.0.1",
+                "unidecode": "^0.1.8"
             }
         },
         "matcher": {
@@ -7578,12 +7601,6 @@
             "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
             "dev": true
         },
-        "string": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
-            "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA=",
-            "dev": true
-        },
         "string-hash": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
@@ -8090,6 +8107,12 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
             "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+            "dev": true
+        },
+        "unidecode": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/unidecode/-/unidecode-0.1.8.tgz",
+            "integrity": "sha1-77swFTi8RSRqmsjFWdcvAVMFBT4=",
             "dev": true
         },
         "union-value": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "eslint-plugin-vue": "^5.2.3",
         "husky": "^3.0.8",
         "markdown-it-container": "^2.0.0",
-        "markdown-it-named-headers": "0.0.4",
+        "markdown-it-named-headings": "^1.1.0",
         "require-extension-hooks": "^0.3.3",
         "require-extension-hooks-babel": "^1.0.0",
         "require-extension-hooks-vue": "^3.0.0",
@@ -54,8 +54,8 @@
         ]
     },
     "husky": {
-      "hooks": {
-        "pre-commit": "npm test"
-      }
+        "hooks": {
+            "pre-commit": "npm test"
+        }
     }
 }

--- a/src/__tests__/vue-markdown-lite.spec.js
+++ b/src/__tests__/vue-markdown-lite.spec.js
@@ -1,14 +1,14 @@
 import test from 'ava'
 import { shallowMount } from '@vue/test-utils'
 import MarkdownLite from '../vue-markdown-lite.vue'
-import headers from 'markdown-it-named-headers'
+import headers from 'markdown-it-named-headings'
 import containers from 'markdown-it-container'
 
 test('renders expected', assert => {
   const wrapper = shallowMount(MarkdownLite, {
     propsData: {
       plugins: [
-        [headers, { slugify: string => string.toLowerCase().replace(/\s/g, '-').replace(/(\.|\?|!)/g, '') }],
+        [headers],
         [containers, 'warning']
       ]
     },


### PR DESCRIPTION
- replace markdown-it-named-headers for markdown-it-named-headings to
avoid security dependency in test code